### PR TITLE
Updated slack in requirements and helper to make way for webhook urls

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ dnspython==2.0.0
 ipwhois==1.2.0
 requests==2.25.1
 shodan==1.25.0
-slackclient==2.9.3
+slack_sdk==3.7.0
 SQLAlchemy==1.4.18
 termcolor==1.1.0
 tqdm==4.61.1

--- a/utilities/MiscHelpers.py
+++ b/utilities/MiscHelpers.py
@@ -1,4 +1,4 @@
-from slack import WebClient
+from slack_sdk.webhook import WebhookClient
 from datetime import datetime
 from termcolor import colored
 from sqlalchemy.exc import IntegrityError
@@ -230,8 +230,8 @@ def generateURLs(db, domain, portscan, timestamp):
 
 
 def slackNotification(token, channel, text):
-	client = WebClient(token=token)
-	client.chat_postMessage(channel=channel, text=text, username="Lepus", icon_emoji=":rabbit2:")
+	client = WebhookClient(token)
+	client.send(channel=channel, text=text, username="Lepus", icon_emoji=":rabbit2:")
 
 
 def exportFindings(db, domain, old_resolved, interrupt):


### PR DESCRIPTION
Updated the Slack requirements file and added changes to the imports in MiscHelpers.py.  As slack now uses webhooks as opposed to tokens for posting data to channels, added the changed WebClient request format.